### PR TITLE
test(infrastructure): add unit tests for infrastructure modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+  - "10"
+cache: yarn
+script:
+  - yarn test
+  - yarn build

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "gen-gql": "apollo client:download-schema && yarn apollo client:codegen --target=typescript"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/src/components/App/component.tsx
+++ b/src/components/App/component.tsx
@@ -24,7 +24,28 @@ export const App: React.FC<AppProps> = () => {
         <AppBar />
         <ContentWrapper>
           <Switch>
-            <Route path="/oauth2/callback" exact render={() => <OAuth2 />} />
+            <Route
+              path="/oauth2/callback"
+              exact
+              render={() => {
+                const searchParams = new URLSearchParams(
+                  window.location.search
+                );
+                const accessToken = searchParams.get("accessToken");
+                const refreshToken = searchParams.get("refreshToken");
+
+                if (!accessToken || !refreshToken) {
+                  throw new Error("Invalid auth redirect URI");
+                }
+
+                return (
+                  <OAuth2
+                    accessToken={accessToken}
+                    refreshToken={refreshToken}
+                  />
+                );
+              }}
+            />
             <Route path="/s" render={() => <SpotsMap />} />
             <Redirect to="/s" />
           </Switch>

--- a/src/components/Oauth2/component.tsx
+++ b/src/components/Oauth2/component.tsx
@@ -4,23 +4,21 @@ import { Redirect } from "react-router";
 import { useLoggedIn } from "../../hooks/useLoggedIn";
 import { useDependency } from "../../di";
 
-export interface OAuth2Props {}
+export interface OAuth2Props {
+  accessToken: string;
+  refreshToken: string;
+}
 
-export const OAuth2: React.FC<OAuth2Props> = () => {
+export const OAuth2: React.FC<OAuth2Props> = ({
+  accessToken,
+  refreshToken
+}) => {
   const isLoggedIn = useLoggedIn();
   const authService = useDependency("authService");
 
   useEffect(() => {
-    const searchParams = new URLSearchParams(window.location.search);
-    const accessToken = searchParams.get("accessToken");
-    const refreshToken = searchParams.get("refreshToken");
-
-    if (!accessToken || !refreshToken) {
-      throw new Error("Invalid auth redirect URI");
-    }
-
     authService.login(accessToken, refreshToken);
-  }, [authService]);
+  }, [authService, accessToken, refreshToken]);
 
   return isLoggedIn ? <Redirect to="/" /> : null;
 };

--- a/src/di/index.ts
+++ b/src/di/index.ts
@@ -1,11 +1,14 @@
 import { createContainer, asClass, asValue } from "awilix";
+
 import { GetSpot } from "../domain/usecase/GetSpot";
 import { SearchSpots } from "../domain/usecase/SearchSpots";
 import { CreateSpot } from "../domain/usecase/CreateSpot";
 import { SpotRepositoryGql } from "../infrastructure/repository/SpotRepositoryGql";
-import { GraphQlService } from "../infrastructure/services/Graphql";
-import { AuthService } from "../infrastructure/services/AuthService";
-import { Cache } from "../infrastructure/services/Cache";
+import { CacheLocalStorage } from "../infrastructure/services/CacheLocalStorage";
+import { GraphQlApolloService } from "../infrastructure/services/GraphqlApollo";
+import { BaseAuthService } from "../infrastructure/services/BaseAuthService";
+import { CachedAuthService } from "../infrastructure/services/CachedAuthService";
+
 import { DiContainer } from "./types";
 
 const apiUrl = process.env.REACT_APP_API_URL;
@@ -23,9 +26,11 @@ const dependencies: DiContainer = {
   apiUrl: asValue(apiUrl),
 
   // Services
-  graphqlService: asClass(GraphQlService).singleton(),
-  authService: asClass(AuthService).singleton(),
-  cache: asClass(Cache).singleton(),
+  graphqlService: asClass(GraphQlApolloService).singleton(),
+  authService: asClass(CachedAuthService)
+    .inject(() => ({ baseAuthService: new BaseAuthService() }))
+    .singleton(),
+  cache: asClass(CacheLocalStorage).singleton(),
 
   // Repositories
   spotRepository: asClass(SpotRepositoryGql).singleton(),

--- a/src/domain/model/Spot.ts
+++ b/src/domain/model/Spot.ts
@@ -12,6 +12,7 @@ export interface Spot {
 }
 
 export class CreateSpotCommand {
+  // eslint-disable-next-line
   constructor(
     public name: string,
     public location: Location,

--- a/src/domain/usecase/GetSpot.test.ts
+++ b/src/domain/usecase/GetSpot.test.ts
@@ -1,0 +1,41 @@
+import { GetSpot } from "./GetSpot";
+import { SpotRepository } from "../repository/SpotRepository";
+import { Spot } from "../model/Spot";
+
+const getSpot = (): Spot => ({
+  id: "spot-id",
+  location: {
+    address: "address",
+    latitude: 0.1,
+    longitude: 0.2
+  },
+  name: "spot name",
+  description: "spot description"
+});
+
+describe("GetSpot", () => {
+  let repository: SpotRepository;
+  let useCase: GetSpot;
+
+  beforeEach(() => {
+    repository = {
+      getSpot: jest.fn(),
+      getSpotsByLocation: jest.fn()
+    };
+    useCase = new GetSpot({ spotRepository: repository });
+  });
+
+  it("execute: should return the spot", async () => {
+    // Given
+    const spotId = "spot-id";
+    (repository.getSpot as jest.Mock).mockResolvedValue(getSpot());
+
+    // When
+    const result = await useCase.execute(spotId);
+
+    // Then
+    expect(repository.getSpot).toHaveBeenCalledTimes(1);
+    expect(repository.getSpot).toHaveBeenCalledWith(spotId);
+    expect(result).toEqual(getSpot());
+  });
+});

--- a/src/domain/usecase/SearchSpots.test.ts
+++ b/src/domain/usecase/SearchSpots.test.ts
@@ -1,0 +1,52 @@
+import { SearchSpots } from "./SearchSpots";
+import { SpotRepository } from "../repository/SpotRepository";
+import { Location } from "../model/Location";
+import { Spot } from "../model/Spot";
+
+const getSpot = (overrides: Partial<Spot> = {}): Spot => ({
+  description: "spot description",
+  id: "spot-id",
+  location: {
+    address: "address",
+    latitude: 0.1,
+    longitude: 0.2
+  },
+  name: "spot name",
+  ...overrides
+});
+
+describe("SearchSpots", () => {
+  let repository: SpotRepository;
+  let useCase: SearchSpots;
+
+  beforeEach(() => {
+    repository = {
+      getSpot: jest.fn(),
+      getSpotsByLocation: jest.fn()
+    };
+    useCase = new SearchSpots({ spotRepository: repository });
+  });
+
+  it("execute: should get the spots in a radius of 7km", async () => {
+    // Given
+    const location: Location = {
+      latitude: 0.1,
+      longitude: 0.2
+    };
+    (repository.getSpotsByLocation as jest.Mock).mockResolvedValue([
+      getSpot({ id: "spot-1" }),
+      getSpot({ id: "spot-2" })
+    ]);
+
+    // When
+    const result = await useCase.execute(location);
+
+    // Then
+    expect(repository.getSpotsByLocation).toHaveBeenCalledTimes(1);
+    expect(repository.getSpotsByLocation).toHaveBeenCalledWith(location, 7);
+    expect(result).toEqual([
+      getSpot({ id: "spot-1" }),
+      getSpot({ id: "spot-2" })
+    ]);
+  });
+});

--- a/src/infrastructure/repository/SpotRepositoryGql.test.ts
+++ b/src/infrastructure/repository/SpotRepositoryGql.test.ts
@@ -1,0 +1,120 @@
+import { SpotRepository } from "../../domain/repository/SpotRepository";
+import { GraphQlService } from "../services/Graphql";
+import { Spot } from "../../domain/model/Spot";
+
+import { SpotRepositoryGql, queries } from "./SpotRepositoryGql";
+import { Location } from "../../domain/model/Location";
+
+const getSpot = (overrides: Partial<Spot> = {}): Spot => ({
+  description: "spot description",
+  id: "spot-id",
+  location: {
+    address: "spot address",
+    latitude: 0.1,
+    longitude: 1.0
+  },
+  name: "spot name",
+  ...overrides
+});
+
+describe("SpotRepositoryGql", () => {
+  let repository: SpotRepository;
+  let graphqlService: GraphQlService;
+
+  beforeEach(() => {
+    graphqlService = {
+      mutate: jest.fn(),
+      query: jest.fn()
+    };
+    repository = new SpotRepositoryGql({ graphqlService });
+  });
+
+  it("getSpot: should call the API with correct params", async () => {
+    // Given
+    const spotId = "spot-id";
+    ((graphqlService.query as any) as jest.Mock).mockResolvedValue({
+      spot: getSpot()
+    });
+
+    // When
+    await repository.getSpot(spotId);
+
+    // Then
+    expect(graphqlService.query).toHaveBeenCalledTimes(1);
+    expect(graphqlService.query).toHaveBeenCalledWith(queries.SPOT, {
+      id: spotId
+    });
+  });
+
+  it("getSpot: should return the spot", async () => {
+    // Given
+    const spotId = "spot-id";
+    ((graphqlService.query as any) as jest.Mock).mockResolvedValue({
+      spot: getSpot()
+    });
+
+    // When
+    const result = await repository.getSpot(spotId);
+
+    // Then
+    expect(result).toEqual(getSpot());
+  });
+
+  it("getSpotsByLocation: should call the API with correct params", async () => {
+    // Given
+    const location: Location = {
+      latitude: 1.0,
+      longitude: 0.1
+    };
+    const radius = 7;
+    ((graphqlService.query as any) as jest.Mock).mockResolvedValue({
+      spots: [
+        getSpot({
+          id: "spot-1"
+        }),
+        getSpot({
+          id: "spot-2"
+        })
+      ]
+    });
+
+    // When
+    await repository.getSpotsByLocation(location, radius);
+
+    // Then
+    expect(graphqlService.query).toHaveBeenCalledTimes(1);
+    expect(graphqlService.query).toHaveBeenCalledWith(queries.SEARCH_SPOT, {
+      latitude: location.latitude,
+      longitude: location.longitude,
+      radius
+    });
+  });
+
+  it("getSpotsByLocation: should return the spots", async () => {
+    // Given
+    const location: Location = {
+      latitude: 1.0,
+      longitude: 0.1
+    };
+    const radius = 7;
+    ((graphqlService.query as any) as jest.Mock).mockResolvedValue({
+      spots: [
+        getSpot({
+          id: "spot-1"
+        }),
+        getSpot({
+          id: "spot-2"
+        })
+      ]
+    });
+
+    // When
+    const results = await repository.getSpotsByLocation(location, radius);
+
+    // Then
+    expect(results).toEqual([
+      getSpot({ id: "spot-1" }),
+      getSpot({ id: "spot-2" })
+    ]);
+  });
+});

--- a/src/infrastructure/repository/SpotRepositoryGql.ts
+++ b/src/infrastructure/repository/SpotRepositoryGql.ts
@@ -4,14 +4,20 @@ import { SpotRepository } from "../../domain/repository/SpotRepository";
 import { Spot, CreateSpotCommand } from "../../domain/model/Spot";
 import { Location } from "../../domain/model/Location";
 import { GraphQlService } from "../services/Graphql";
-import { spot, spotVariables } from "./queries/__generated__/spot";
-import { spotsVariables, spots } from "./queries/__generated__/spots";
 import {
-  createSpot,
-  createSpotVariables
+  FetchSpot,
+  FetchSpotVariables
+} from "./queries/__generated__/FetchSpot";
+import {
+  SearchSpotsVariables,
+  SearchSpots
+} from "./queries/__generated__/SearchSpots";
+import {
+  CreateSpotVariables,
+  CreateSpot
 } from "./queries/__generated__/createSpot";
 
-const queries = {
+export const queries = {
   SPOT: loader("./queries/spot.graphql"),
   SEARCH_SPOT: loader("./queries/search-spots.graphql"),
   CREATE_SPOT: loader("./queries/create-spot.graphql")
@@ -30,7 +36,7 @@ export class SpotRepositoryGql implements SpotRepository {
 
   public getSpot(id: string): Promise<Spot> {
     return this.graphql
-      .query<spotVariables, spot>(queries.SPOT, {
+      .query<FetchSpotVariables, FetchSpot>(queries.SPOT, {
         id
       })
       .then(response => response.spot);
@@ -41,7 +47,7 @@ export class SpotRepositoryGql implements SpotRepository {
     radius: number
   ): Promise<Spot[]> {
     return this.graphql
-      .query<spotsVariables, spots>(queries.SEARCH_SPOT, {
+      .query<SearchSpotsVariables, SearchSpots>(queries.SEARCH_SPOT, {
         latitude: location.latitude,
         longitude: location.longitude,
         radius
@@ -51,7 +57,7 @@ export class SpotRepositoryGql implements SpotRepository {
 
   public createSpot(createSpot: CreateSpotCommand) {
     return this.graphql
-      .mutate<createSpotVariables, createSpot>(queries.CREATE_SPOT, {
+      .mutate<CreateSpotVariables, CreateSpot>(queries.CREATE_SPOT, {
         description: createSpot.description,
         latitude: createSpot.location.latitude,
         longitude: createSpot.location.longitude,

--- a/src/infrastructure/repository/queries/__generated__/FetchSpot.ts
+++ b/src/infrastructure/repository/queries/__generated__/FetchSpot.ts
@@ -3,28 +3,28 @@
 // This file was automatically generated and should not be edited.
 
 // ====================================================
-// GraphQL query operation: spot
+// GraphQL query operation: FetchSpot
 // ====================================================
 
-export interface spot_spot_location {
+export interface FetchSpot_spot_location {
   __typename: "Location";
   latitude: number;
   longitude: number;
   address: string | null;
 }
 
-export interface spot_spot {
+export interface FetchSpot_spot {
   __typename: "Spot";
   id: string;
   name: string;
   description: string | null;
-  location: spot_spot_location;
+  location: FetchSpot_spot_location;
 }
 
-export interface spot {
-  spot: spot_spot;
+export interface FetchSpot {
+  spot: FetchSpot_spot;
 }
 
-export interface spotVariables {
+export interface FetchSpotVariables {
   id: string;
 }

--- a/src/infrastructure/repository/queries/__generated__/SearchSpots.ts
+++ b/src/infrastructure/repository/queries/__generated__/SearchSpots.ts
@@ -3,29 +3,29 @@
 // This file was automatically generated and should not be edited.
 
 // ====================================================
-// GraphQL query operation: spots
+// GraphQL query operation: SearchSpots
 // ====================================================
 
-export interface spots_spots_location {
+export interface SearchSpots_spots_location {
   __typename: "Location";
   latitude: number;
   longitude: number;
   address: string | null;
 }
 
-export interface spots_spots {
+export interface SearchSpots_spots {
   __typename: "Spot";
   id: string;
   name: string;
   description: string | null;
-  location: spots_spots_location;
+  location: SearchSpots_spots_location;
 }
 
-export interface spots {
-  spots: spots_spots[];
+export interface SearchSpots {
+  spots: SearchSpots_spots[];
 }
 
-export interface spotsVariables {
+export interface SearchSpotsVariables {
   latitude: number;
   longitude: number;
   radius: number;

--- a/src/infrastructure/repository/queries/__generated__/createSpot.ts
+++ b/src/infrastructure/repository/queries/__generated__/createSpot.ts
@@ -3,29 +3,29 @@
 // This file was automatically generated and should not be edited.
 
 // ====================================================
-// GraphQL mutation operation: createSpot
+// GraphQL mutation operation: CreateSpot
 // ====================================================
 
-export interface createSpot_createSpot_location {
+export interface CreateSpot_createSpot_location {
   __typename: "Location";
   latitude: number;
   longitude: number;
   address: string | null;
 }
 
-export interface createSpot_createSpot {
+export interface CreateSpot_createSpot {
   __typename: "Spot";
   id: string;
   name: string;
   description: string | null;
-  location: createSpot_createSpot_location;
+  location: CreateSpot_createSpot_location;
 }
 
-export interface createSpot {
-  createSpot: createSpot_createSpot;
+export interface CreateSpot {
+  createSpot: CreateSpot_createSpot;
 }
 
-export interface createSpotVariables {
+export interface CreateSpotVariables {
   name: string;
   description?: string | null;
   latitude: number;

--- a/src/infrastructure/repository/queries/create-spot.graphql
+++ b/src/infrastructure/repository/queries/create-spot.graphql
@@ -1,4 +1,4 @@
-mutation createSpot(
+mutation CreateSpot(
   $name: String!
   $description: String
   $latitude: Float!

--- a/src/infrastructure/repository/queries/search-spots.graphql
+++ b/src/infrastructure/repository/queries/search-spots.graphql
@@ -1,4 +1,4 @@
-query spots($latitude: Float!, $longitude: Float!, $radius: Float!) {
+query SearchSpots($latitude: Float!, $longitude: Float!, $radius: Float!) {
   spots(
     filter: { latitude: $latitude, longitude: $longitude, radius: $radius }
   ) {

--- a/src/infrastructure/repository/queries/spot.graphql
+++ b/src/infrastructure/repository/queries/spot.graphql
@@ -1,4 +1,4 @@
-query spot($id: String!) {
+query FetchSpot($id: String!) {
   spot(id: $id) {
     id
     name

--- a/src/infrastructure/services/AuthService.ts
+++ b/src/infrastructure/services/AuthService.ts
@@ -1,60 +1,18 @@
-import { Cache } from "./Cache";
-
-interface Dependencies {
-  cache: Cache;
+export interface Tokens {
+  accessToken: string | null;
+  refreshToken: string | null;
 }
 
-type Subscriber = (isLoggedIn: boolean) => void;
+export type AuthSubscriber = (isLoggedIn: boolean) => void;
 
-export class AuthService {
-  private cache: Cache;
-  private accessToken: string | null;
-  private refreshToken: string | null;
-  private subscribers: Subscriber[];
+export interface AuthService {
+  login(accessToken: string, refreshToken: string): void;
 
-  public constructor({ cache }: Dependencies) {
-    this.cache = cache;
-    this.accessToken = this.cache.getItem("accessToken");
-    this.refreshToken = this.cache.getItem("refreshToken");
-    this.subscribers = [];
-  }
+  logout(): void;
 
-  public login(accessToken: string, refreshToken: string) {
-    this.accessToken = accessToken;
-    this.refreshToken = refreshToken;
+  getTokens(): Tokens;
 
-    this.cache.setItem("accessToken", this.accessToken);
-    this.cache.setItem("refreshToken", this.refreshToken);
+  isLoggedIn(): boolean;
 
-    this.subscribers.forEach(subscriber => subscriber(this.isLoggedIn()));
-  }
-
-  public logout() {
-    this.accessToken = null;
-    this.refreshToken = null;
-
-    this.cache.removeItem("accessToken");
-    this.cache.removeItem("refreshToken");
-
-    this.subscribers.forEach(subscriber => subscriber(this.isLoggedIn()));
-  }
-
-  public getTokens() {
-    return {
-      accessToken: this.accessToken,
-      refreshToken: this.refreshToken
-    };
-  }
-
-  public isLoggedIn() {
-    return Boolean(this.accessToken);
-  }
-
-  public subscribe(subscriber: Subscriber) {
-    this.subscribers.push(subscriber);
-
-    return () => {
-      this.subscribers = this.subscribers.filter(x => x !== subscriber);
-    };
-  }
+  subscribe(subscriber: AuthSubscriber): () => void;
 }

--- a/src/infrastructure/services/BaseAuthService.test.ts
+++ b/src/infrastructure/services/BaseAuthService.test.ts
@@ -1,0 +1,107 @@
+import { BaseAuthService } from "./BaseAuthService";
+import { Cache } from "./Cache";
+
+describe("BaseAuthService", () => {
+  let authService: BaseAuthService;
+
+  beforeEach(() => {
+    authService = new BaseAuthService();
+  });
+
+  it("login: should set the access token", () => {
+    // Given
+    const accessToken = "access-token";
+
+    // When
+    authService.login(accessToken, "");
+
+    // Then
+    expect(authService.getTokens().accessToken).toEqual(accessToken);
+  });
+
+  it("login: should set the refresh token", () => {
+    // Given
+    const refreshToken = "refresh-token";
+
+    // When
+    authService.login("", refreshToken);
+
+    // Then
+    expect(authService.getTokens().refreshToken).toEqual(refreshToken);
+  });
+
+  it("logout: should reset the access token", () => {
+    // Given
+    const accessToken = "access-token";
+    authService.login(accessToken, "");
+
+    // When
+    authService.logout();
+
+    // Then
+    expect(authService.getTokens().accessToken).toBeNull();
+  });
+
+  it("logout: should reset the refresh token", () => {
+    // Given
+    const refreshToken = "refresh-token";
+    authService.login("", refreshToken);
+
+    // When
+    authService.logout();
+
+    // Then
+    expect(authService.getTokens().refreshToken).toBeNull();
+  });
+
+  it("getTokens: should return the tokens", () => {
+    // Given
+    const accessToken = "access-token";
+    const refreshToken = "refresh-token";
+    authService.login(accessToken, refreshToken);
+
+    // When
+    const result = authService.getTokens();
+
+    // Then
+    expect(result).toEqual({
+      accessToken,
+      refreshToken
+    });
+  });
+
+  it("isLoggedIn: should return true when the access token is set", () => {
+    // Given
+    const accessToken = "access-token";
+    authService.login(accessToken, "");
+
+    // When
+    const result = authService.isLoggedIn();
+
+    // Then
+    expect(result).toBe(true);
+  });
+
+  it("isLoggedIn: should return false when the access token is not set", () => {
+    // When
+    const result = authService.isLoggedIn();
+
+    // Then
+    expect(result).toBe(false);
+  });
+
+  it("subscribe: should set a new listener", () => {
+    // Given
+    const subscriber = jest.fn();
+
+    // When
+    authService.subscribe(subscriber);
+    authService.login("", "");
+    authService.logout();
+
+    // Then
+    expect(subscriber).toHaveBeenCalledTimes(2);
+    expect(subscriber).toHaveBeenNthCalledWith(1, true);
+    expect(subscriber).toHaveBeenNthCalledWith(2, false);
+  });
+});

--- a/src/infrastructure/services/BaseAuthService.ts
+++ b/src/infrastructure/services/BaseAuthService.ts
@@ -1,0 +1,46 @@
+import { AuthService, AuthSubscriber } from "./AuthService";
+
+export class BaseAuthService implements AuthService {
+  private accessToken: string | null;
+  private refreshToken: string | null;
+  private subscribers: AuthSubscriber[];
+
+  public constructor() {
+    this.accessToken = null;
+    this.refreshToken = null;
+    this.subscribers = [];
+  }
+
+  public login(accessToken: string, refreshToken: string) {
+    this.accessToken = accessToken;
+    this.refreshToken = refreshToken;
+
+    this.subscribers.forEach(subscriber => subscriber(true));
+  }
+
+  public logout() {
+    this.accessToken = null;
+    this.refreshToken = null;
+
+    this.subscribers.forEach(subscriber => subscriber(false));
+  }
+
+  public getTokens() {
+    return {
+      accessToken: this.accessToken,
+      refreshToken: this.refreshToken
+    };
+  }
+
+  public isLoggedIn() {
+    return Boolean(this.accessToken);
+  }
+
+  public subscribe(subscriber: AuthSubscriber) {
+    this.subscribers.push(subscriber);
+
+    return () => {
+      this.subscribers = this.subscribers.filter(x => x !== subscriber);
+    };
+  }
+}

--- a/src/infrastructure/services/Cache.ts
+++ b/src/infrastructure/services/Cache.ts
@@ -1,13 +1,7 @@
-export class Cache {
-  public setItem(key: string, value: string) {
-    localStorage.setItem(key, value);
-  }
+export interface Cache {
+  setItem(key: string, value: string): void;
 
-  public getItem(key: string) {
-    return localStorage.getItem(key);
-  }
+  getItem(key: string): string | null;
 
-  public removeItem(key: string) {
-    localStorage.removeItem(key);
-  }
+  removeItem(key: string): void;
 }

--- a/src/infrastructure/services/CacheLocalStorage.ts
+++ b/src/infrastructure/services/CacheLocalStorage.ts
@@ -1,0 +1,15 @@
+import { Cache } from "./Cache";
+
+export class CacheLocalStorage implements Cache {
+  public setItem(key: string, value: string) {
+    localStorage.setItem(key, value);
+  }
+
+  public getItem(key: string) {
+    return localStorage.getItem(key);
+  }
+
+  public removeItem(key: string) {
+    localStorage.removeItem(key);
+  }
+}

--- a/src/infrastructure/services/CachedAuthService.test.ts
+++ b/src/infrastructure/services/CachedAuthService.test.ts
@@ -1,0 +1,133 @@
+import { CachedAuthService } from "./CachedAuthService";
+import { Cache } from "./Cache";
+import { AuthService } from "./AuthService";
+
+describe("CachedAuthService", () => {
+  let cache: Cache;
+  let baseAuthService: AuthService;
+  let cachedAuthService: AuthService;
+
+  beforeEach(() => {
+    cache = {
+      getItem: jest.fn(),
+      removeItem: jest.fn(),
+      setItem: jest.fn()
+    };
+    baseAuthService = {
+      getTokens: jest.fn(),
+      isLoggedIn: jest.fn(),
+      login: jest.fn(),
+      logout: jest.fn(),
+      subscribe: jest.fn().mockReturnValue(() => {})
+    };
+    cachedAuthService = new CachedAuthService({
+      cache,
+      baseAuthService
+    });
+  });
+
+  it("login: should login the decorated auth service", () => {
+    // Given
+    const accessToken = "access-token";
+    const refreshToken = "refresh-token";
+
+    // When
+    cachedAuthService.login(accessToken, refreshToken);
+
+    // Then
+    expect(baseAuthService.login).toHaveBeenCalledTimes(1);
+    expect(baseAuthService.login).toHaveBeenCalledWith(
+      accessToken,
+      refreshToken
+    );
+  });
+
+  it("login: should cache the access token", () => {
+    // Given
+    const accessToken = "access-token";
+
+    // When
+    cachedAuthService.login(accessToken, "");
+
+    // Then
+    expect(cache.setItem).toHaveBeenCalledWith("accessToken", accessToken);
+  });
+
+  it("login: should cache the refresh token", () => {
+    // Given
+    const refreshToken = "refresh-token";
+
+    // When
+    cachedAuthService.login("", refreshToken);
+
+    // Then
+    expect(cache.setItem).toHaveBeenCalledWith("refreshToken", refreshToken);
+  });
+
+  it("logout: should un-cache the access token", () => {
+    // Given
+    const accessToken = "access-token";
+    cachedAuthService.login(accessToken, "");
+
+    // When
+    cachedAuthService.logout();
+
+    // Then
+    expect(cache.removeItem).toHaveBeenCalledWith("accessToken");
+  });
+
+  it("logout: should un-cache the refresh token", () => {
+    // Given
+    const refreshToken = "refresh-token";
+    cachedAuthService.login("", refreshToken);
+
+    // When
+    cachedAuthService.logout();
+
+    // Then
+    expect(cache.removeItem).toHaveBeenCalledWith("refreshToken");
+  });
+
+  it("getTokens: should return the result of the decorated service", () => {
+    // Given
+    const accessToken = "access-token";
+    const refreshToken = "refresh-token";
+    (baseAuthService.getTokens as jest.Mock).mockReturnValue({
+      accessToken,
+      refreshToken
+    });
+
+    // When
+    const result = cachedAuthService.getTokens();
+
+    // Then
+    expect(result).toEqual({
+      accessToken,
+      refreshToken
+    });
+  });
+
+  it("isLoggedIn: should return the result of the decorated service", () => {
+    // Given
+    (baseAuthService.isLoggedIn as jest.Mock).mockReturnValue(false);
+
+    // When
+    const result = cachedAuthService.isLoggedIn();
+
+    // Then
+    expect(result).toBe(false);
+  });
+
+  it("subscriber: should subscriber to the decorated service", () => {
+    // Given
+    const subscriber = jest.fn();
+
+    // When
+    const unsubscribe = cachedAuthService.subscribe(subscriber);
+
+    // Then
+    expect(baseAuthService.subscribe).toHaveBeenCalledTimes(1);
+    expect(baseAuthService.subscribe).toHaveBeenCalledWith(subscriber);
+    expect(unsubscribe).toEqual(expect.any(Function));
+  });
+});

--- a/src/infrastructure/services/CachedAuthService.ts
+++ b/src/infrastructure/services/CachedAuthService.ts
@@ -1,0 +1,50 @@
+import { AuthService, AuthSubscriber } from "./AuthService";
+import { Cache } from "./Cache";
+
+interface Dependencies {
+  baseAuthService: AuthService;
+  cache: Cache;
+}
+
+export class CachedAuthService implements AuthService {
+  private authService: AuthService;
+  private cache: Cache;
+
+  public constructor({ baseAuthService, cache }: Dependencies) {
+    this.authService = baseAuthService;
+    this.cache = cache;
+
+    const accessToken = this.cache.getItem("accessToken");
+    const refreshToken = this.cache.getItem("refreshToken");
+
+    if (accessToken && refreshToken) {
+      this.authService.login(accessToken, refreshToken);
+    }
+  }
+
+  public getTokens() {
+    return this.authService.getTokens();
+  }
+
+  public isLoggedIn() {
+    return this.authService.isLoggedIn();
+  }
+
+  public login(accessToken: string, refreshToken: string) {
+    this.authService.login(accessToken, refreshToken);
+
+    this.cache.setItem("accessToken", accessToken);
+    this.cache.setItem("refreshToken", refreshToken);
+  }
+
+  public logout() {
+    this.authService.logout();
+
+    this.cache.removeItem("accessToken");
+    this.cache.removeItem("refreshToken");
+  }
+
+  public subscribe(subscriber: AuthSubscriber) {
+    return this.authService.subscribe(subscriber);
+  }
+}

--- a/src/infrastructure/services/Graphql.ts
+++ b/src/infrastructure/services/Graphql.ts
@@ -1,59 +1,11 @@
-import ApolloClient from "apollo-boost";
-
-import { AuthService } from "./AuthService";
-
-interface Dependencies {
-  apiUrl: string;
-  authService: AuthService;
-}
-
-export class GraphQlService {
-  private client: ApolloClient<any>;
-  private authService: AuthService;
-
-  public constructor({ apiUrl, authService }: Dependencies) {
-    this.authService = authService;
-    this.client = new ApolloClient({
-      uri: `${apiUrl}/graphql`
-    });
-  }
-
-  public query<Variables extends {}, Response>(
+export interface GraphQlService {
+  query<Variables extends {}, Response>(
     query: any,
     variables: Variables
-  ): Promise<Response> {
-    return this.client
-      .query<Response, Variables>({
-        query,
-        variables,
-        context: {
-          headers: this.getHeaders()
-        }
-      })
-      .then(response => response.data);
-  }
+  ): Promise<Response>;
 
-  public mutate<Variables extends {}, Response>(
+  mutate<Variables extends {}, Response>(
     mutation: any,
     variables: Variables
-  ): Promise<Response> {
-    return this.client.mutate<Response, Variables>({
-      mutation,
-      variables,
-      context: {
-        headers: this.getHeaders()
-      }
-    });
-  }
-
-  private getHeaders() {
-    const { accessToken } = this.authService.getTokens();
-    const headers: any = {};
-
-    if (accessToken) {
-      headers.Authorization = `Bearer ${accessToken}`;
-    }
-
-    return headers;
-  }
+  ): Promise<Response>;
 }

--- a/src/infrastructure/services/GraphqlApollo.ts
+++ b/src/infrastructure/services/GraphqlApollo.ts
@@ -1,0 +1,60 @@
+import ApolloClient from "apollo-boost";
+
+import { AuthService } from "./AuthService";
+import { GraphQlService } from "./Graphql";
+
+interface Dependencies {
+  apiUrl: string;
+  authService: AuthService;
+}
+
+export class GraphQlApolloService implements GraphQlService {
+  private client: ApolloClient<any>;
+  private authService: AuthService;
+
+  public constructor({ apiUrl, authService }: Dependencies) {
+    this.authService = authService;
+    this.client = new ApolloClient({
+      uri: `${apiUrl}/graphql`
+    });
+  }
+
+  public query<Variables extends {}, Response>(
+    query: any,
+    variables: Variables
+  ): Promise<Response> {
+    return this.client
+      .query<Response, Variables>({
+        query,
+        variables,
+        context: {
+          headers: this.getHeaders()
+        }
+      })
+      .then(response => response.data);
+  }
+
+  public mutate<Variables extends {}, Response>(
+    mutation: any,
+    variables: Variables
+  ): Promise<Response> {
+    return this.client.mutate<Response, Variables>({
+      mutation,
+      variables,
+      context: {
+        headers: this.getHeaders()
+      }
+    });
+  }
+
+  private getHeaders() {
+    const { accessToken } = this.authService.getTokens();
+    const headers: any = {};
+
+    if (accessToken) {
+      headers.Authorization = `Bearer ${accessToken}`;
+    }
+
+    return headers;
+  }
+}


### PR DESCRIPTION
A few things have changed :
1 - I added some unit tests for repositories, services, ...
2 - I extracted some logic from a component to the router parent
3 - I split the `AuthService` into several modules.

Explanation for 3:
- The previous implementation handler auth + caching the tokens to the cache. This violated SRP.
- I used the decorator design pattern to extract the caching behaviour to a `CachedAuthService` with simply handles the caching mechanism but forwards all operation to another AuthService implementation