### PR TITLE
Use refresh token when access token is expired or invalid

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
+    "lint": "eslint --ext .ts . --fix",
     "gen-gql": "apollo client:download-schema && yarn apollo client:codegen --target=typescript"
   },
   "eslintConfig": {

--- a/src/components/SpotsMap/styles.ts
+++ b/src/components/SpotsMap/styles.ts
@@ -6,6 +6,8 @@ export const Wrapper = styled.div`
   overflow: hidden;
 
   .map {
+    position: absolute;
+    width: 100%;
     height: 100%;
   }
 `;

--- a/src/di/index.ts
+++ b/src/di/index.ts
@@ -10,6 +10,7 @@ import { BaseAuthService } from "../infrastructure/services/BaseAuthService";
 import { CachedAuthService } from "../infrastructure/services/CachedAuthService";
 
 import { DiContainer } from "./types";
+import { FetchHttpService } from "../infrastructure/services/FetchHttpService";
 
 const apiUrl = process.env.REACT_APP_API_URL;
 
@@ -26,10 +27,10 @@ const dependencies: DiContainer = {
   apiUrl: asValue(apiUrl),
 
   // Services
+  httpService: asClass(FetchHttpService).singleton(),
   graphqlService: asClass(GraphQlApolloService).singleton(),
-  authService: asClass(CachedAuthService)
-    .inject(() => ({ baseAuthService: new BaseAuthService() }))
-    .singleton(),
+  baseAuthService: asClass(BaseAuthService).singleton(),
+  authService: asClass(CachedAuthService).singleton(),
   cache: asClass(CacheLocalStorage).singleton(),
 
   // Repositories

--- a/src/di/types.ts
+++ b/src/di/types.ts
@@ -3,6 +3,7 @@ import { Resolver } from "awilix";
 import { GraphQlService } from "../infrastructure/services/Graphql";
 import { AuthService } from "../infrastructure/services/AuthService";
 import { Cache } from "../infrastructure/services/Cache";
+import { HttpService } from "../infrastructure/services/HttpService";
 import { SpotRepository } from "../domain/repository/SpotRepository";
 import { GetSpot } from "../domain/usecase/GetSpot";
 import { SearchSpots } from "../domain/usecase/SearchSpots";
@@ -13,7 +14,9 @@ export interface DiContainer {
   apiUrl: Resolver<string>;
 
   // Services
+  httpService: Resolver<HttpService>;
   graphqlService: Resolver<GraphQlService>;
+  baseAuthService: Resolver<AuthService>;
   authService: Resolver<AuthService>;
   cache: Resolver<Cache>;
 

--- a/src/infrastructure/services/AuthService.ts
+++ b/src/infrastructure/services/AuthService.ts
@@ -15,4 +15,6 @@ export interface AuthService {
   isLoggedIn(): boolean;
 
   subscribe(subscriber: AuthSubscriber): () => void;
+
+  refreshTokens(): Promise<void>;
 }

--- a/src/infrastructure/services/BaseAuthService.test.ts
+++ b/src/infrastructure/services/BaseAuthService.test.ts
@@ -1,11 +1,16 @@
 import { BaseAuthService } from "./BaseAuthService";
 import { Cache } from "./Cache";
+import { HttpService, successResponse, failureResponse } from "./HttpService";
 
 describe("BaseAuthService", () => {
   let authService: BaseAuthService;
+  let httpService: HttpService;
 
   beforeEach(() => {
-    authService = new BaseAuthService();
+    httpService = {
+      post: jest.fn().mockResolvedValue(null)
+    };
+    authService = new BaseAuthService({ httpService });
   });
 
   it("login: should set the access token", () => {
@@ -103,5 +108,52 @@ describe("BaseAuthService", () => {
     expect(subscriber).toHaveBeenCalledTimes(2);
     expect(subscriber).toHaveBeenNthCalledWith(1, true);
     expect(subscriber).toHaveBeenNthCalledWith(2, false);
+  });
+
+  it("refreshTokens: should post /refresh", async () => {
+    // Given
+    const refreshToken = "refresh-token";
+    (httpService.post as jest.Mock).mockResolvedValue(
+      successResponse(200, { accessToken: "" })
+    );
+    authService.login("access-token", refreshToken);
+
+    // When
+    await authService.refreshTokens();
+
+    // Then
+    expect(httpService.post).toHaveBeenCalledTimes(1);
+    expect(httpService.post).toHaveBeenCalledWith("/refresh", {
+      refreshToken
+    });
+  });
+
+  it("refreshTokens: should refresh the access token on success", async () => {
+    // Given
+    const accessToken = "access-token";
+    (httpService.post as jest.Mock).mockResolvedValue(
+      successResponse(200, { accessToken })
+    );
+
+    // When
+    await authService.refreshTokens();
+
+    // Then
+    expect(authService.getTokens().accessToken).toEqual(accessToken);
+  });
+
+  it("refreshTokens: should logout on failure", async () => {
+    // Given
+    const accessToken = "access-token";
+    (httpService.post as jest.Mock).mockResolvedValue(
+      failureResponse(403, new Error("Something went wrong"))
+    );
+
+    // When
+    await authService.refreshTokens();
+
+    // Then
+    expect(authService.getTokens().accessToken).toEqual(null);
+    expect(authService.getTokens().refreshToken).toEqual(null);
   });
 });

--- a/src/infrastructure/services/BaseAuthService.test.ts
+++ b/src/infrastructure/services/BaseAuthService.test.ts
@@ -1,5 +1,4 @@
 import { BaseAuthService } from "./BaseAuthService";
-import { Cache } from "./Cache";
 import { HttpService, successResponse, failureResponse } from "./HttpService";
 
 describe("BaseAuthService", () => {
@@ -144,7 +143,6 @@ describe("BaseAuthService", () => {
 
   it("refreshTokens: should logout on failure", async () => {
     // Given
-    const accessToken = "access-token";
     (httpService.post as jest.Mock).mockResolvedValue(
       failureResponse(403, new Error("Something went wrong"))
     );

--- a/src/infrastructure/services/CachedAuthService.test.ts
+++ b/src/infrastructure/services/CachedAuthService.test.ts
@@ -18,6 +18,7 @@ describe("CachedAuthService", () => {
       isLoggedIn: jest.fn(),
       login: jest.fn(),
       logout: jest.fn(),
+      refreshTokens: jest.fn(),
       subscribe: jest.fn().mockReturnValue(() => {})
     };
     cachedAuthService = new CachedAuthService({
@@ -129,5 +130,17 @@ describe("CachedAuthService", () => {
     expect(baseAuthService.subscribe).toHaveBeenCalledTimes(1);
     expect(baseAuthService.subscribe).toHaveBeenCalledWith(subscriber);
     expect(unsubscribe).toEqual(expect.any(Function));
+  });
+
+  it("refreshTokens: should return the result of the decorated service", async () => {
+    // Given
+    (baseAuthService.refreshTokens as jest.Mock).mockResolvedValue(null);
+
+    // When
+    const result = await cachedAuthService.refreshTokens();
+
+    // Then
+    expect(result).toBe(null);
+    expect(baseAuthService.refreshTokens).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/infrastructure/services/CachedAuthService.test.ts
+++ b/src/infrastructure/services/CachedAuthService.test.ts
@@ -135,6 +135,10 @@ describe("CachedAuthService", () => {
   it("refreshTokens: should return the result of the decorated service", async () => {
     // Given
     (baseAuthService.refreshTokens as jest.Mock).mockResolvedValue(null);
+    (baseAuthService.getTokens as jest.Mock).mockReturnValue({
+      accessToken: "access-token",
+      refreshToken: "refresh-token"
+    });
 
     // When
     const result = await cachedAuthService.refreshTokens();
@@ -142,5 +146,22 @@ describe("CachedAuthService", () => {
     // Then
     expect(result).toBe(null);
     expect(baseAuthService.refreshTokens).toHaveBeenCalledTimes(1);
+  });
+
+  it("refreshTokens: should cache the new access token", async () => {
+    // Given
+    const accessToken = "access-token";
+    (baseAuthService.refreshTokens as jest.Mock).mockResolvedValue(null);
+    (baseAuthService.getTokens as jest.Mock).mockReturnValue({
+      accessToken,
+      refreshToken: "refresh-token"
+    });
+
+    // When
+    const result = await cachedAuthService.refreshTokens();
+
+    // Then
+    expect(cache.setItem).toHaveBeenCalledTimes(1);
+    expect(cache.setItem).toHaveBeenCalledWith("accessToken", accessToken);
   });
 });

--- a/src/infrastructure/services/CachedAuthService.ts
+++ b/src/infrastructure/services/CachedAuthService.ts
@@ -47,4 +47,8 @@ export class CachedAuthService implements AuthService {
   public subscribe(subscriber: AuthSubscriber) {
     return this.authService.subscribe(subscriber);
   }
+
+  public refreshTokens() {
+    return this.authService.refreshTokens();
+  }
 }

--- a/src/infrastructure/services/CachedAuthService.ts
+++ b/src/infrastructure/services/CachedAuthService.ts
@@ -49,6 +49,14 @@ export class CachedAuthService implements AuthService {
   }
 
   public refreshTokens() {
-    return this.authService.refreshTokens();
+    return this.authService.refreshTokens().then(value => {
+      const accessToken = this.authService.getTokens().accessToken;
+
+      if (accessToken) {
+        this.cache.setItem("accessToken", accessToken);
+      }
+
+      return value;
+    });
   }
 }

--- a/src/infrastructure/services/FetchHttpService.ts
+++ b/src/infrastructure/services/FetchHttpService.ts
@@ -1,0 +1,36 @@
+import {
+  HttpService,
+  HttpResponse,
+  successResponse,
+  failureResponse
+} from "./HttpService";
+
+interface Dependencies {
+  apiUrl: string;
+}
+
+export class FetchHttpService implements HttpService {
+  private apiUrl: string;
+
+  constructor({ apiUrl }: Dependencies) {
+    this.apiUrl = apiUrl;
+  }
+
+  public post<T>(path: string, body: any): Promise<HttpResponse<T>> {
+    const url = `${this.apiUrl}${path}`;
+
+    return fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify(body)
+    }).then(async response => {
+      if (response.ok) {
+        return successResponse(response.status, await response.json());
+      }
+
+      return failureResponse(response.status, new Error("Network error"));
+    });
+  }
+}

--- a/src/infrastructure/services/GraphqlApollo.ts
+++ b/src/infrastructure/services/GraphqlApollo.ts
@@ -2,7 +2,6 @@ import ApolloClient from "apollo-boost";
 
 import { AuthService } from "./AuthService";
 import { GraphQlService } from "./Graphql";
-import { HttpService } from "./HttpService";
 
 interface Dependencies {
   apiUrl: string;

--- a/src/infrastructure/services/HttpService.ts
+++ b/src/infrastructure/services/HttpService.ts
@@ -1,0 +1,41 @@
+interface BaseResponse {
+  statusCode: number;
+}
+
+interface SuccessResponse<T> extends BaseResponse {
+  isSuccess: true;
+  data: T;
+}
+
+interface FailureResponse extends BaseResponse {
+  isSuccess: false;
+  error: Error;
+}
+
+export type HttpResponse<T> = SuccessResponse<T> | FailureResponse;
+
+export interface HttpService {
+  post<T>(path: string, body: any): Promise<HttpResponse<T>>;
+}
+
+export function successResponse<T>(
+  statusCode: number,
+  data: T
+): SuccessResponse<T> {
+  return {
+    isSuccess: true,
+    data,
+    statusCode
+  };
+}
+
+export function failureResponse(
+  statusCode: number,
+  error: Error
+): FailureResponse {
+  return {
+    isSuccess: false,
+    error,
+    statusCode
+  };
+}


### PR DESCRIPTION
This Pull Request comes with the matching server-side feature : https://github.com/codenights/spottit-backend/pull/4

When the API responds with 401, we automatically call `/refresh` to get a new access token, and replay HTTP calls with the new token. If for some reason the server cannot refresh the access token, then the user is logged out.