### PR TITLE
chore(deps): add Dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,5 @@
+version: 1
+update_configs:
+  - package_manager: 'javascript'
+    directory: '/'
+    update_schedule: 'live'


### PR DESCRIPTION
## Description

This adds Dependabot to the repository to update the dependencies as soon as a new dependency is released. We can change the `update_schedule` to `"weekly"` if this creates too much noise.

## Related

- codenights/spottit-backend#17