### PR TITLE
Proposal : synchronize Apollo cache using an event dispatcher

### DIFF
--- a/src/di/index.ts
+++ b/src/di/index.ts
@@ -1,4 +1,5 @@
-import { createContainer, asClass, asValue } from 'awilix'
+import { createContainer, asClass, asValue, asFunction } from 'awilix'
+import ApolloClient from 'apollo-boost'
 
 import { GetSpot } from '../domain/usecase/GetSpot'
 import { SearchSpots } from '../domain/usecase/SearchSpots'
@@ -13,6 +14,8 @@ import { CachedAuthService } from '../infrastructure/services/CachedAuthService'
 import { FetchHttpService } from '../infrastructure/services/FetchHttpService'
 
 import { DiContainer } from './types'
+import { EventDispatcher } from '../domain/events/Dispatcher'
+import { OnCommentAdded } from '../infrastructure/events/OnCommentAdded'
 
 const apiUrl = process.env.REACT_APP_API_URL
 
@@ -24,9 +27,18 @@ if (!apiUrl) {
 
 export const container = createContainer()
 
+const apollo = new ApolloClient({
+  uri: `${apiUrl}/graphql`,
+})
+
 const dependencies: DiContainer = {
   // Configuration
   apiUrl: asValue(apiUrl),
+  apollo: asValue(apollo),
+
+  // Events
+  eventDispatcher: asClass(EventDispatcher).singleton(),
+  onCommentAdded: asFunction(OnCommentAdded).singleton(),
 
   // Services
   httpService: asClass(FetchHttpService).singleton(),

--- a/src/di/types.ts
+++ b/src/di/types.ts
@@ -1,19 +1,27 @@
 import { Resolver } from 'awilix'
+import { ApolloClient } from 'apollo-boost'
 
 import { GraphQlService } from '../infrastructure/services/Graphql'
 import { AuthService } from '../infrastructure/services/AuthService'
 import { Cache } from '../infrastructure/services/Cache'
 import { HttpService } from '../infrastructure/services/HttpService'
+import { OnCommentAdded } from '../infrastructure/events/OnCommentAdded'
 import { SpotRepository } from '../domain/repository/SpotRepository'
 import { CommentRepository } from '../domain/repository/CommentRepository'
 import { GetSpot } from '../domain/usecase/GetSpot'
 import { SearchSpots } from '../domain/usecase/SearchSpots'
 import { CreateSpot } from '../domain/usecase/CreateSpot'
 import { AddComment } from '../domain/usecase/AddComment'
+import { EventDispatcher, AppEventListener } from '../domain/events/Dispatcher'
 
 export interface DiContainer {
   // Configuration
   apiUrl: Resolver<string>
+  apollo: Resolver<ApolloClient<any>>
+
+  // Events
+  eventDispatcher: Resolver<EventDispatcher>
+  onCommentAdded: Resolver<AppEventListener>
 
   // Services
   httpService: Resolver<HttpService>

--- a/src/domain/events/Dispatcher.ts
+++ b/src/domain/events/Dispatcher.ts
@@ -1,0 +1,23 @@
+import { Event } from './Event'
+
+export type AppEventListener = (event: Event) => void
+
+export class EventDispatcher {
+  private listeners: AppEventListener[]
+
+  public constructor() {
+    this.listeners = []
+  }
+
+  public listen(listener: AppEventListener) {
+    this.listeners.push(listener)
+
+    return () => this.listeners.filter(x => x !== listener)
+  }
+
+  public dispatch(event: Event) {
+    this.listeners.forEach(listener => {
+      listener(event)
+    })
+  }
+}

--- a/src/domain/events/Event.ts
+++ b/src/domain/events/Event.ts
@@ -1,0 +1,15 @@
+export interface EventCommentAdded {
+  type: 'comment_added'
+  comment: {
+    spotId: string
+    author: {
+      id: string
+      username: string
+    }
+    body: string
+    createdAt: string
+    id: string
+  }
+}
+
+export type Event = EventCommentAdded

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,32 +1,39 @@
-import "reset.css/reset.css";
-import "leaflet/dist/leaflet.css";
+import 'reset.css/reset.css'
+import 'leaflet/dist/leaflet.css'
 
-import React from "react";
-import ReactDOM from "react-dom";
+import React from 'react'
+import ReactDOM from 'react-dom'
 
-import L from "leaflet";
-import icon from "leaflet/dist/images/marker-icon.png";
-import iconShadow from "leaflet/dist/images/marker-shadow.png";
+import L from 'leaflet'
+import icon from 'leaflet/dist/images/marker-icon.png'
+import iconShadow from 'leaflet/dist/images/marker-shadow.png'
 
-import { container, context as DiContext } from "./di";
-import { App } from "./components/App";
-import * as serviceWorker from "./serviceWorker";
+import { container, context as DiContext } from './di'
+import { App } from './components/App'
+import * as serviceWorker from './serviceWorker'
+import { EventDispatcher, AppEventListener } from './domain/events/Dispatcher'
 
 let DefaultIcon = L.icon({
   iconUrl: icon,
-  shadowUrl: iconShadow
-});
+  shadowUrl: iconShadow,
+})
 
-L.Marker.prototype.options.icon = DefaultIcon;
+L.Marker.prototype.options.icon = DefaultIcon
+
+// Register events handlers
+const eventDispatcher = container.resolve<EventDispatcher>('eventDispatcher')
+const onCommentAdded = container.resolve<AppEventListener>('onCommentAdded')
+
+eventDispatcher.listen(onCommentAdded)
 
 ReactDOM.render(
   <DiContext.Provider value={() => container}>
     <App />
   </DiContext.Provider>,
-  document.getElementById("root")
-);
+  document.getElementById('root')
+)
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.
 // Learn more about service workers: https://bit.ly/CRA-PWA
-serviceWorker.unregister();
+serviceWorker.unregister()

--- a/src/infrastructure/events/OnCommentAdded.ts
+++ b/src/infrastructure/events/OnCommentAdded.ts
@@ -1,0 +1,47 @@
+import { ApolloClient } from 'apollo-boost'
+
+import { AppEventListener } from '../../domain/events/Dispatcher'
+
+import { queries } from '../repository/SpotRepositoryGql'
+import {
+  FetchSpot,
+  FetchSpotVariables,
+} from '../repository/queries/__generated__/FetchSpot'
+
+export interface Dependencies {
+  apollo: ApolloClient<any>
+}
+
+export const OnCommentAdded = ({
+  apollo,
+}: Dependencies): AppEventListener => event => {
+  if (event.type === 'comment_added') {
+    const data = apollo.cache.readQuery<FetchSpot, FetchSpotVariables>({
+      query: queries.SPOT,
+      variables: {
+        id: event.comment.spotId,
+      },
+    })
+
+    if (!data) {
+      return
+    }
+
+    data.spot.comments.push({
+      __typename: 'Comment',
+      author: {
+        __typename: 'User',
+        id: event.comment.author.id,
+        username: event.comment.author.username,
+      },
+      body: event.comment.body,
+      createdAt: event.comment.createdAt,
+      id: event.comment.id,
+    })
+
+    apollo.cache.writeQuery({
+      query: queries.SPOT,
+      data,
+    })
+  }
+}

--- a/src/infrastructure/repository/queries/__generated__/AddComment.ts
+++ b/src/infrastructure/repository/queries/__generated__/AddComment.ts
@@ -6,9 +6,24 @@
 // GraphQL mutation operation: AddComment
 // ====================================================
 
+export interface AddComment_addComment_author {
+  __typename: "User";
+  id: string;
+  username: string;
+}
+
+export interface AddComment_addComment_spot {
+  __typename: "Spot";
+  id: string;
+}
+
 export interface AddComment_addComment {
   __typename: "Comment";
   id: string;
+  author: AddComment_addComment_author;
+  spot: AddComment_addComment_spot;
+  body: string;
+  createdAt: string;
 }
 
 export interface AddComment {

--- a/src/infrastructure/repository/queries/add-comment.graphql
+++ b/src/infrastructure/repository/queries/add-comment.graphql
@@ -1,5 +1,14 @@
 mutation AddComment($spotId: String!, $body: String!) {
   addComment(input: { spotId: $spotId, body: $body }) {
     id
+    author {
+      id
+      username
+    }
+    spot {
+      id
+    }
+    body
+    createdAt
   }
 }


### PR DESCRIPTION
As seen in this PR : https://github.com/codenights/spottit-frontend/pull/21 we need to explicitly set the fetch policy to `no-cache` so that apollo will re-fetch fresh data once a comment has been added.

This behavior will be true for any mutation impacting a view on the screen.

Apollo provides a solution for this, we can manually write data to its cache (https://www.apollographql.com/docs/react/advanced/caching/).

In order to keep our repository agnostic from GraphQL, and keep our `GraphQLService` generic, I would like to suggest the following architecture :

- an event dispatcher is created once for the app (`domain/events/Dispatcher.ts`).
- "side-effect"-ish modules can register to this dispatcher (see `infrastructure/events/OnCommentAdded.ts`)
- the repositories can access the event dispatcher in their dependencies
- when they perform an action (like creating a comment for instance), they publish (dispatch) an event to the event dispatcher.
- if a listener is interested in the event, they can perform side effects.

In this example, the `OnCommendAdded` listener listen to `comment_added` events, which are published by the `CommentRepositoryGql` module, and updates the matching Apollo query.